### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  helper_method :sold_out
 
   def index
     @items = Item.includes(:user,:dealing).order('created_at DESC')
@@ -51,5 +52,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def sold_out(id)
+    Dealing.find_by(item_id: id).present?
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <% if @items.present? %>
@@ -133,13 +133,11 @@
               <div class='item-img-content'>
                 <%= image_tag item.images[0], class: "item-img" %>
 
-              <%# 購入機能実装の際、実行%>           
-                <%# if @order.item_id.present? %>
-                  <%# <div class='sold-out'> %>
-                    <%# <span>Sold Out!!</span> %>
-                  <%# </div> %>
-                <%# end %>
-              <%# //購入機能実装の際、実行%>
+                <% if Dealing.find_by(item_id: item.id).present? %>
+                  <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                  </div>
+                <% end %>
 
               </div>
               <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
               <div class='item-img-content'>
                 <%= image_tag item.images[0], class: "item-img" %>
 
-                <% if Dealing.find_by(item_id: item.id).present? %>
+                <% if sold_out(item) %>
                   <div class='sold-out'>
                     <span>Sold Out!!</span>
                   </div>


### PR DESCRIPTION
#What
・index.html.erbを編集
・sold out表示、投稿ページへのリンク未設定箇所を編集

#Why
商品一覧表示機能実装のため

＊これが最後の実装であるため、他ページへの遷移などはすでにLGTMをもらっている。
＊sold out表示は、前の商品購入機能実装の際に一度設定し、動作は確認済み、LGTMを受けている。

＜ログイン時＞
![member](https://user-images.githubusercontent.com/68336848/89605049-976f1900-d8a7-11ea-9487-84182cd7c36b.gif)

＜未ログイン時＞
![visitor](https://user-images.githubusercontent.com/68336848/89605159-d7360080-d8a7-11ea-9729-becb5d2bd188.gif)